### PR TITLE
Use `v2` OAuth endpoints

### DIFF
--- a/tap_autodesk_bim_360/client.py
+++ b/tap_autodesk_bim_360/client.py
@@ -37,7 +37,7 @@ class BIM360Client(object):
     def refresh_user_access_token(self):
         data = self.request(
             'POST',
-            url='https://developer.api.autodesk.com/authentication/v1/refreshtoken',
+            url='https://developer.api.autodesk.com/authentication/v2/token',
             data={
                 'client_id': self.__client_id,
                 'client_secret': self.__client_secret,
@@ -61,7 +61,7 @@ class BIM360Client(object):
     def refresh_app_access_token(self):
         data = self.request(
             'POST',
-            url='https://developer.api.autodesk.com/authentication/v1/authenticate',
+            url='https://developer.api.autodesk.com/authentication/v2/token',
             data={
                 'client_id': self.__client_id,
                 'client_secret': self.__client_secret,


### PR DESCRIPTION
# Description of change
`v1` OAuth endpoints are deprecated as of 30/04/2024
- https://aps.autodesk.com/blog/important-update-authentication-v1-deprecation-extended-april-30th-2024-act-now
- https://aps.autodesk.com/blog/migration-guide-oauth2-v1-v2

# Manual QA steps
 - Run the tap
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
